### PR TITLE
Fixed MegaMan(CPPNto)GANLevelBreederTask

### DIFF
--- a/src/main/java/edu/southwestern/tasks/megaman/MegaManCPPNtoGANLevelBreederTask.java
+++ b/src/main/java/edu/southwestern/tasks/megaman/MegaManCPPNtoGANLevelBreederTask.java
@@ -61,7 +61,7 @@ public class MegaManCPPNtoGANLevelBreederTask extends InteractiveEvolutionTask<T
 	private String[] outputLabels;
 
 	MegaManGANGenerator megaManGenerator;
-	MegaManTrackSegmentType segmentCount;
+	MegaManTrackSegmentType segmentCount = new MegaManTrackSegmentType();
 	
 	private boolean initializationComplete = false;
 	

--- a/src/main/java/edu/southwestern/tasks/megaman/MegaManCPPNtoGANLevelBreederTask.java
+++ b/src/main/java/edu/southwestern/tasks/megaman/MegaManCPPNtoGANLevelBreederTask.java
@@ -578,7 +578,7 @@ public class MegaManCPPNtoGANLevelBreederTask extends InteractiveEvolutionTask<T
 	public static void main(String[] args) throws FileNotFoundException, NoSuchMethodException {
 		try {
 			MMNEAT.main(new String[]{"runNumber:0","randomSeed:1","useMultipleGANsMegaMan:false","showKLOptions:false","trials:1","mu:16", "base:megaManGAN",
-					"maxGens:500","io:false","netio:false","GANInputSize:5","mating:true","fs:false",
+					"maxGens:500","io:false","netio:false","GANInputSize:5","mating:true","fs:false","megaManGANLevelChunks:10",
 					"task:edu.southwestern.tasks.megaman.MegaManCPPNtoGANLevelBreederTask","cleanOldNetworks:false", 
 					"allowMultipleFunctions:true","ftype:0","watch:true","netChangeActivationRate:0.3","cleanFrequency:-1",
 					"simplifiedInteractiveInterface:false","recurrency:false","saveAllChampions:true","cleanOldNetworks:false",

--- a/src/main/java/edu/southwestern/tasks/megaman/MegaManGANLevelBreederTask.java
+++ b/src/main/java/edu/southwestern/tasks/megaman/MegaManGANLevelBreederTask.java
@@ -55,7 +55,7 @@ public class MegaManGANLevelBreederTask extends InteractiveGANLevelEvolutionTask
 	public static final int VIEW_BUTTON_INDEX = -19; 
 	public static final int GANS_BUTTON_INDEX = -18; 
 	MegaManGANGenerator megaManGenerator;
-	MegaManTrackSegmentType segmentCount;
+	MegaManTrackSegmentType segmentCount = new MegaManTrackSegmentType();
 
 	
 	//public static GANProcess ganProcessDown = null;
@@ -751,7 +751,7 @@ public class MegaManGANLevelBreederTask extends InteractiveGANLevelEvolutionTask
 	 */
 	public static void main(String[] args) {
 		try {
-			MMNEAT.main(new String[]{"runNumber:0","randomSeed:1","bigInteractiveButtons:false","megaManUsesUniqueEnemies:false","GANInputSize:5","showKLOptions:false","trials:1","mu:16","maxGens:500","io:false","netio:false","mating:true","fs:false","task:edu.southwestern.tasks.megaman.MegaManGANLevelBreederTask","watch:true","cleanFrequency:-1","genotype:edu.southwestern.evolution.genotypes.BoundedRealValuedGenotype","simplifiedInteractiveInterface:false","saveAllChampions:true","ea:edu.southwestern.evolution.selectiveBreeding.SelectiveBreedingEA","imageWidth:2000","imageHeight:2000","imageSize:200"});
+			MMNEAT.main(new String[]{"runNumber:0","randomSeed:1","megaManGANLevelChunks:10","bigInteractiveButtons:false","megaManUsesUniqueEnemies:false","GANInputSize:5","useMultipleGANsMegaMan:true","showKLOptions:false","trials:1","mu:16","maxGens:500","io:false","netio:false","mating:true","fs:false","task:edu.southwestern.tasks.megaman.MegaManGANLevelBreederTask","watch:true","cleanFrequency:-1","genotype:edu.southwestern.evolution.genotypes.BoundedRealValuedGenotype","simplifiedInteractiveInterface:false","saveAllChampions:true","ea:edu.southwestern.evolution.selectiveBreeding.SelectiveBreedingEA","imageWidth:2000","imageHeight:2000","imageSize:200"});
 		} catch (FileNotFoundException | NoSuchMethodException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Small but important fix. Essentially, segmentCount had to be initialized for both classes to avoid null pointer exceptions. In addition, the default number of segments was changed from 1 to 10 to automatically generate actual levels.